### PR TITLE
Update youtube model to fix URL structuring. 

### DIFF
--- a/src/app/shared/models/social-networks.ts
+++ b/src/app/shared/models/social-networks.ts
@@ -66,8 +66,12 @@ export const SocialNetworks: SocialNetwork[] = [
         label: 'User'
       },
       {
-        value: 'c',
+        value: 'channel',
         label: 'Channel'
+      },
+      {
+        value: 'c',
+        label: 'Custom'
       }
     ],
     value: 'yt',


### PR DESCRIPTION
Three types of accounts: user - old/legacy, channel - new accounts, c for custom - vanity URLs for 'established' accounts.